### PR TITLE
Check for letters in any language

### DIFF
--- a/src/StrServiceProvider.php
+++ b/src/StrServiceProvider.php
@@ -18,9 +18,10 @@ class StrServiceProvider extends ServiceProvider
             }
 
             $acronym = '';
-            foreach (preg_split('/[^a-zA-Z]+/', $string) as $word) {
+            foreach (preg_split('/[^\p{L}]+/u', $string) as $word) {
                 if(!empty($word)){
-                    $acronym .= $word[0] . $delimiter;
+                    $first_letter = mb_substr($word, 0, 1);
+                    $acronym .= $first_letter . $delimiter;
                 }
             }
 

--- a/tests/AcronymStrTest.php
+++ b/tests/AcronymStrTest.php
@@ -21,6 +21,7 @@ class AcronymStrTest extends TestCase
         $this->assertSame('ts', Str::acronym('trailing spaces   '));
         $this->assertSame('ty', Str::acronym('the year 2013'));
         $this->assertSame('lpf', Str::acronym("laravel\t\tphp\n\nframework"));
+        $this->assertSame('ÉL', Str::acronym("Érico Leitão"));
         $this->assertSame('HW', (string) Str::of('hello world')->headline()->acronym());
     }
 }


### PR DESCRIPTION
Acronym for "Érico Leitão" would result in 'rLo' instead of 'ÉL'. I've added a test for it and modified the regex to match these letters. 

Also changed getting the first letter to mb_substr to prevent loss of e.g. UTF-8 characters.